### PR TITLE
Improve reliability of split-gpg2-client

### DIFF
--- a/split-gpg2-client
+++ b/split-gpg2-client
@@ -3,12 +3,7 @@
 agent_socket=`gpgconf --list-dirs | grep '^agent-socket:' | cut -d ':' -f 2`
 
 if [ -S "$agent_socket" ]; then
-    agent_pid=`lsof -F p "$agent_socket" 2>/dev/null | grep '^p' | cut -b 2-`
-
-    if [ -n $agent_pid ]; then
-        kill $agent_pid
-    fi
-
+    lsof -F p "$agent_socket" 2>/dev/null | grep '^p' | cut -b 2- | xargs -r kill
     rm -f "$agent_socket"
 fi
 

--- a/split-gpg2-client
+++ b/split-gpg2-client
@@ -3,7 +3,7 @@
 agent_socket=`gpgconf --list-dirs | grep '^agent-socket:' | cut -d ':' -f 2`
 
 if [ -S "$agent_socket" ]; then
-    agent_pid=`lsof -F p "$agent_socket" | cut -b 2-`
+    agent_pid=`lsof -F p "$agent_socket" 2>/dev/null | grep '^p' | cut -b 2-`
 
     if [ -n $agent_pid ]; then
         kill $agent_pid


### PR DESCRIPTION
Currently, split-gpg2-client has two problems:
1. It assumes that lsof prints only the requested field ('p'), which it doesn't (my version adds 'f' lines).
2. It doesn't quote $agent_pid.

The two commits in this PR filter lsof's output and pass every found pid to kill (note the -r argument to xargs), also eliminating the conditional using the unquoted $agent_pid.